### PR TITLE
Fixing incoherence between last_committed_date / ignore_before_date

### DIFF
--- a/git_contributions_importer/Importer.py
+++ b/git_contributions_importer/Importer.py
@@ -71,7 +71,7 @@ class Importer:
             print('\nStarting')
             last_committed_date = 0
 
-        for c in self.get_all_commits(last_committed_date):
+        for c in self.get_all_commits(last_committed_date+1):
             print('\nAnalysing commit at ' + time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(c.committed_date)))
 
             if self.author is not None:


### PR DESCRIPTION
Hello,

this PR fixes this issue : https://github.com/miromannino/Contributions-Importer-For-Github/issues/25

there is an incoherence between last_commited_date and ignore_before_date, that cause the last commit to be repeated twice.

with this PR, ignore_before_date will be last_committed_date+1 to ensure that current commit is not repeated.

thanks.